### PR TITLE
fix: bug in the dfs logic  - task.id was never checked

### DIFF
--- a/src/app/services/item_service.py
+++ b/src/app/services/item_service.py
@@ -228,7 +228,7 @@ def get_item_by_id_dfs_iterative(
 
                     for task in lab.tasks:
                         counter += 1
-                        if lab.id == item_id:
+                        if task.id == item_id:
                             return FoundItem(task, counter)
 
                         for step in task.steps:


### PR DESCRIPTION
fix: bug in the dfs logic  

- task.id was never checked
